### PR TITLE
Don't keep any the(any, …) assertion

### DIFF
--- a/prolog/mavis.pl
+++ b/prolog/mavis.pl
@@ -130,7 +130,7 @@ build_type_assertions(Slash, Head, TypeGoal) :-
 
     Head =.. [Name|HeadArgs],
     maplist(type_declaration, HeadArgs, ModeArgs, AllTypes),
-    exclude(=@=(the(any, _)), AllTypes, Types),
+    exclude(=(the(any, _)), AllTypes, Types),
     xfy_list(',', TypeGoal, Types).
 
 build_determinism_assertions(Goal,Wrapped) :-


### PR DESCRIPTION
Currently since we require `=@=`, `the(any, X)` will be removed from the list of assertions, but `the(any, [])` will not, even if it doesn't contribute anything (it will always be true). I fail to see why mavis keeps those…

BTW, I have another issue (unrelated and for which I don't have a fix right now), but Issues don't seem to be open on this project…